### PR TITLE
Update timestamp to be RFC3339 sec. 5.6 compliant

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -27,7 +27,7 @@ python do_cyclonedx_init() {
         "serialNumber": "urn:uuid:" + str(uuid.uuid4()),
         "version": 1,
         "metadata": {
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now().astimezone().isoformat(),
             "tools": [{"name": "yocto"}]
         },
         "components": []


### PR DESCRIPTION
CycloneDX's JSON schema uses the predefined date-time format which according to the [JSON schema docs](https://json-schema.org/understanding-json-schema/reference/string#dates-and-times) corresponds to [RFC3339 sec. 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6), which is a subset of [ISO8601](https://datatracker.ietf.org/doc/html/rfc3339#ref-ISO8601).

Thus, a valid SBOM does NOT support all forms of ISO8601 date formats.