### PR TITLE
Take build system CVE information into account

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 SPDX-License-Identifier: MIT
 
 Copyright (C) 2024 Savoir-faire Linux Inc. (<www.savoirfairelinux.com>).
+Copyright (C) 2024 iris-GmbH infrared & intelligent sensors
 
 Based on previous work from `github.com/bgnetworks/meta-dependencytrack`:  
 Copyright 2022 BG Networks, Inc.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # meta-cyclonedx
 
-`meta-cyclonedx` is a [Yocto](https://www.yoctoproject.org/) meta-layer which produces a [CycloneDX](https://cyclonedx.org/) Software Bill of Materials (aka [SBOM](https://www.ntia.gov/SBOM)) from your root filesystem.  
+`meta-cyclonedx` is a [Yocto](https://www.yoctoproject.org/) meta-layer which produces [CycloneDX](https://cyclonedx.org/) Software Bill of Materials (aka [SBOM](https://www.ntia.gov/SBOM)) from your root filesystem.
+
 This repository is forked from [BG Networks repository](https://github.com/bgnetworks/meta-dependencytrack) but differs by the following:
-- Removed support for DependencyTrack.
+- Removed direct integration with DependencyTrack.
 - Exported CycloneDX include packages, but also vulnerabilities found by Yocto.
-- generation of CPE is fixed and also generate purl for packages.
+- Generation of CPE is fixed and also generate purl for packages.
+- Added generation of an additional CycloneDX VEX file which contains information on patched and ignored CVEs from within the Yocto Build System.
 
 ## Installation
 
@@ -23,14 +25,47 @@ BBLAYERS += "${BSPDIR}/sources/meta-cyclonedx"
 
 ## Configuration
 
-To enable and configure the layer simply inherit the `cyclonedx-export` class in your `local.conf` file and then set the following variables:
-
-### Example
+To enable and configure the layer simply inherit the `cyclonedx-export` class in your `local.conf` file and then set the following variable:
 
 ```sh
 INHERIT += "cyclonedx-export"
 ```
 
-## Building and Uploading
+## Building
 
-Once everything is configured simply build your image as you normally would. The final CycloneDX SBOM is saved as `tmp/deploy/cyclonedx-export/bom.json` and, after buiding is complete, you should be able to simply refresh the project in Dependency Track to see the results of the scan.
+Once everything is configured simply build your image as you normally would.
+
+Alternatively, if you are only interested in the CycloneDX files, you may append your bitbake command with `--runonly=do_cyclonedx_package_collect` which will limit bitbake to run only the required tasks for creating the CycloneDX output.
+
+By default the final CycloneDX SBOMs are saved in the folder `${DEPLOY_DIR}/cyclonedx-export` as `bom.json` and `vex.json` respectively.
+
+## Uploading to DependencyTrack (tested against DT v4.11.4)
+
+While this layer does not offer a direct integration with DependencyTrack (we consider that a feature, since it removes dependencies to external infrastructure in your build), it is perfectly possible to use the produced SBOMs within DependencyTrack.
+
+At the time of writing DependencyTrack does not support uploading component and vulnerability information in one go (which is why we currently create two separate files). The status on this may be tracked [here](https://github.com/DependencyTrack/dependency-track/issues/919).
+
+### Manual Upload
+
+1. Go into an existing project in your DependencyTrack instance or create a new one.
+2. Go to the *Components* tab and click *Upload BOM*.
+3. Select the `bom.json` file from your deploy directory.
+4. Wait for the vulnerability analysis to complete.
+5. Go to the *Audit Vulnerabilities* tab and click *Apply VEX*.
+6. Select the `vex.json` file from your deploy directory.
+
+### Automated Upload
+
+You may want to script the upload of the SBOMs to DependencyTrack, e.g. as part of a CI job that runs after your build is complete.
+
+This is possible by leveraging DependencyTracks REST API.
+
+At the time of writing this can be done by leveraging the following API endpoints:
+
+1. `/v1/bom` for uploading the `bom.json`.
+2. `/v1/event/token/{uuid}` for checking the status on the `bom.json` processing.
+3. `/v1/vex` for uploading the `vex.json`.
+
+Please refer to [DependencyTracks REST API documentation](https://docs.dependencytrack.org/integrations/rest-api/) for the usage of these endpoints as well as the required token permissions.
+
+In the future we might include an example script in this repository.

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -112,7 +112,7 @@ python do_cyclonedx_package_collect() {
     write_json(d.getVar("CYCLONEDX_EXPORT_VEX"), vex)
 }
 
-addtask do_cyclonedx_package_collect before do_build after do_fetch
+addtask do_cyclonedx_package_collect before do_build
 do_cyclonedx_package_collect[nostamp] = "1"
 do_cyclonedx_package_collect[lockfiles] += "${CYCLONEDX_EXPORT_LOCK}"
 do_rootfs[recrdeptask] += "do_cyclonedx_package_collect"

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -80,32 +80,45 @@ python do_cyclonedx_package_collect() {
             # populate vex file with patched CVEs
             for _, patched_cve in enumerate(oe.cve_check.get_patched_cves(d)):
                 bb.debug(2, f"Found patch for CVE {patched_cve} in {name}@{version}")
-                vex["vulnerabilities"].append({
-                    "id": patched_cve,
-                    # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
-                    # this should always be NVD for yocto CVEs.
-                    "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{patched_cve}"},
-                    "analysis": {"state": "resolved"},
-                    # Hint: Component specific resolving seems not to work at the moment when using DependencyTrack
-                    # resolution will of CVE will be applied to all components within the project that contain the CVE
-                    "affects": [{"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}]
-                })
+                index_found = next((i for i, v in enumerate(vex["vulnerabilities"]) if v["id"] == patched_cve), None)
+                if index_found is None:
+                    vex["vulnerabilities"].append({
+                        "id": patched_cve,
+                        # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
+                        # this should always be NVD for yocto CVEs.
+                        "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{patched_cve}"},
+                        "analysis": {"state": "resolved"},
+                        # Hint: Component specific resolving seems not to work at the moment when using DependencyTrack
+                        # resolution will of CVE will be applied to all components within the project that contain the CVE
+                        "affects": [{"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}]
+                    })
+                else:
+                    vex["vulnerabilities"][index_found]["affects"].append(
+                        {"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}
+                    )
+
             # populate vex file with ignored CVEs defined in CVE_CHECK_IGNORE
             cve_check_ignore = d.getVar("CVE_CHECK_IGNORE")
             if cve_check_ignore is not None:
                 for ignored_cve in cve_check_ignore.split():
                     bb.debug(2, f"Found ignore statement for CVE {ignored_cve} in {name}@{version}")
-                    vex["vulnerabilities"].append({
-                        "id": ignored_cve,
-                        # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
-                        # this should always be NVD for yocto CVEs.
-                        "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{ignored_cve}"},
-                        # setting not-affected state for ignored CVEs
-                        "analysis": {"state": "not_affected"},
-                        # Hint: Component specific resolving seems not to work at the moment when using DependencyTrack
-                        # resolution will of CVE will be applied to all components within the project that contain the CVE
-                        "affects": [{"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}]
-                    })
+                    index_found = next((i for i, v in enumerate(vex["vulnerabilities"]) if v["id"] == ignored_cve), None)
+                    if index_found is None:
+                        vex["vulnerabilities"].append({
+                            "id": ignored_cve,
+                            # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
+                            # this should always be NVD for yocto CVEs.
+                            "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{ignored_cve}"},
+                            # setting not-affected state for ignored CVEs
+                            "analysis": {"state": "not_affected"},
+                            # Hint: Component specific resolving seems not to work at the moment when using DependencyTrack
+                            # resolution will of CVE will be applied to all components within the project that contain the CVE
+                            "affects": [{"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}]
+                        })
+                    else:
+                        vex["vulnerabilities"][index_found]["affects"].append(
+                            {"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}
+                        )
     
     # write it back to the deploy directory
     write_json(d.getVar("CYCLONEDX_EXPORT_SBOM"), sbom)

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -64,7 +64,16 @@ python do_cyclonedx_package_collect() {
             return
 
     # load the bom
-    name = d.getVar("CVE_PRODUCT")
+    products = d.getVar("CVE_PRODUCT")
+    # if this has been unset then we're not scanning for CVEs here (for example, image recipes)
+    if not products:
+        return
+
+    # if the recipe has been skipped/ignored we return
+    if d.getVar("PN") in (d.getVar("CVE_CHECK_SKIP_RECIPE") or "").split():
+        bb.note("Recipe has been skipped by cyclonedx package collect")
+        return
+
     version = d.getVar("CVE_VERSION")
     sbom = read_json(d.getVar("CYCLONEDX_EXPORT_SBOM"))
     # extract the sbom serial number without "urn:uuid:" prefix
@@ -72,14 +81,14 @@ python do_cyclonedx_package_collect() {
     sbom_serial_number = sbom["serialNumber"][len("urn:uuid:"):]
     vex = read_json(d.getVar("CYCLONEDX_EXPORT_VEX"))
 
-    for pkg in generate_packages_list(name, version):
+    for pkg in generate_packages_list(products, version):
         if not next((c for c in sbom["components"] if c["cpe"] == pkg["cpe"]), None):
             sbom["components"].append(pkg)
             bom_ref = pkg["bom-ref"]
 
             # populate vex file with patched CVEs
             for _, patched_cve in enumerate(oe.cve_check.get_patched_cves(d)):
-                bb.debug(2, f"Found patch for CVE {patched_cve} in {name}@{version}")
+                bb.debug(2, f"Found patch for CVE {patched_cve} in {pkg['name']}@{version}")
                 index_found = next((i for i, v in enumerate(vex["vulnerabilities"]) if v["id"] == patched_cve), None)
                 if index_found is None:
                     vex["vulnerabilities"].append({
@@ -101,7 +110,7 @@ python do_cyclonedx_package_collect() {
             cve_check_ignore = d.getVar("CVE_CHECK_IGNORE")
             if cve_check_ignore is not None:
                 for ignored_cve in cve_check_ignore.split():
-                    bb.debug(2, f"Found ignore statement for CVE {ignored_cve} in {name}@{version}")
+                    bb.debug(2, f"Found ignore statement for CVE {ignored_cve} in {pkg['name']}@{version}")
                     index_found = next((i for i, v in enumerate(vex["vulnerabilities"]) if v["id"] == ignored_cve), None)
                     if index_found is None:
                         vex["vulnerabilities"].append({

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -15,7 +15,7 @@ CYCLONEDX_EXPORT_LOCK ??= "${CYCLONEDX_EXPORT_TMP}/bom.lock"
 
 python do_cyclonedx_init() {
     import uuid
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     timestamp = datetime.now(timezone.utc).isoformat()
     sbom_dir = d.getVar("CYCLONEDX_EXPORT_DIR")

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -58,6 +58,11 @@ do_cyclonedx_init[eventmask] = "bb.event.BuildStarted"
 python do_cyclonedx_package_collect() {
     import oe.cve_check
 
+    # ignore non-target packages
+    for ignored_suffix in (d.getVar("SPECIAL_PKGSUFFIX") or "").split():
+        if d.getVar("PN").endswith(ignored_suffix):
+            return
+
     # load the bom
     name = d.getVar("CVE_PRODUCT")
     version = d.getVar("CVE_VERSION")

--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -9,6 +9,7 @@ CVE_VERSION ??= "${PV}"
 
 CYCLONEDX_EXPORT_DIR ??= "${DEPLOY_DIR}/cyclonedx-export"
 CYCLONEDX_EXPORT_SBOM ??= "${CYCLONEDX_EXPORT_DIR}/bom.json"
+CYCLONEDX_EXPORT_VEX ??= "${CYCLONEDX_EXPORT_DIR}/vex.json"
 CYCLONEDX_EXPORT_TMP ??= "${TMPDIR}/cyclonedx-export"
 CYCLONEDX_EXPORT_LOCK ??= "${CYCLONEDX_EXPORT_TMP}/bom.lock"
 
@@ -16,38 +17,94 @@ python do_cyclonedx_init() {
     import uuid
     from datetime import datetime
 
+    timestamp = datetime.now(timezone.utc).isoformat()
     sbom_dir = d.getVar("CYCLONEDX_EXPORT_DIR")
     bb.debug(2, "Creating cyclonedx directory: %s" % sbom_dir)
     bb.utils.mkdirhier(sbom_dir)
 
-    bb.debug(2, "Creating empty sbom")
-    write_sbom(d, {
+    # Generate unique serial numbers for sbom and vex document
+    sbom_serial_number = str(uuid.uuid4())
+    vex_serial_number = str(uuid.uuid4())
+
+    bb.debug(2, f"Creating empty sbom file with serial number {sbom_serial_number}")
+    write_json(d.getVar("CYCLONEDX_EXPORT_SBOM"), {
         "bomFormat": "CycloneDX",
         "specVersion": "1.4",
-        "serialNumber": "urn:uuid:" + str(uuid.uuid4()),
+        "serialNumber": f"urn:uuid:{sbom_serial_number}",
         "version": 1,
         "metadata": {
-            "timestamp": datetime.now().astimezone().isoformat(),
+            "timestamp": timestamp,
             "tools": [{"name": "yocto"}]
         },
         "components": []
+    })
+
+    bb.debug(2, f"Creating empty vex file with serial number {vex_serial_number}")
+    write_json(d.getVar("CYCLONEDX_EXPORT_VEX"), {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.4",
+        "serialNumber": f"urn:uuid:{vex_serial_number}",
+        "version": 1,
+        "metadata": {
+            "timestamp": timestamp,
+            "tools": [{"name": "yocto"}]
+        },
+        "vulnerabilities": []
     })
 }
 addhandler do_cyclonedx_init
 do_cyclonedx_init[eventmask] = "bb.event.BuildStarted"
 
 python do_cyclonedx_package_collect() {
+    import oe.cve_check
+
     # load the bom
     name = d.getVar("CVE_PRODUCT")
     version = d.getVar("CVE_VERSION")
-    sbom = read_sbom(d)
+    sbom = read_json(d.getVar("CYCLONEDX_EXPORT_SBOM"))
+    # extract the sbom serial number without "urn:uuid:" prefix
+    # (avoid using builtin str.removeprefix function as Python >= 3.9 required)
+    sbom_serial_number = sbom["serialNumber"][len("urn:uuid:"):]
+    vex = read_json(d.getVar("CYCLONEDX_EXPORT_VEX"))
 
     for pkg in generate_packages_list(name, version):
         if not next((c for c in sbom["components"] if c["cpe"] == pkg["cpe"]), None):
             sbom["components"].append(pkg)
+            bom_ref = pkg["bom-ref"]
 
+            # populate vex file with patched CVEs
+            for _, patched_cve in enumerate(oe.cve_check.get_patched_cves(d)):
+                bb.debug(2, f"Found patch for CVE {patched_cve} in {name}@{version}")
+                vex["vulnerabilities"].append({
+                    "id": patched_cve,
+                    # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
+                    # this should always be NVD for yocto CVEs.
+                    "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{patched_cve}"},
+                    "analysis": {"state": "resolved"},
+                    # Hint: Component specific resolving seems not to work at the moment when using DependencyTrack
+                    # resolution will of CVE will be applied to all components within the project that contain the CVE
+                    "affects": [{"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}]
+                })
+            # populate vex file with ignored CVEs defined in CVE_CHECK_IGNORE
+            cve_check_ignore = d.getVar("CVE_CHECK_IGNORE")
+            if cve_check_ignore is not None:
+                for ignored_cve in cve_check_ignore.split():
+                    bb.debug(2, f"Found ignore statement for CVE {ignored_cve} in {name}@{version}")
+                    vex["vulnerabilities"].append({
+                        "id": ignored_cve,
+                        # vex documents require a valid source, see https://github.com/DependencyTrack/dependency-track/issues/2977
+                        # this should always be NVD for yocto CVEs.
+                        "source": {"name": "NVD", "url": f"https://nvd.nist.gov/vuln/detail/{ignored_cve}"},
+                        # setting not-affected state for ignored CVEs
+                        "analysis": {"state": "not_affected"},
+                        # Hint: Component specific resolving seems not to work at the moment when using DependencyTrack
+                        # resolution will of CVE will be applied to all components within the project that contain the CVE
+                        "affects": [{"ref": f"urn:cdx:{sbom_serial_number}/1#{bom_ref}"}]
+                    })
+    
     # write it back to the deploy directory
-    write_sbom(d, sbom)
+    write_json(d.getVar("CYCLONEDX_EXPORT_SBOM"), sbom)
+    write_json(d.getVar("CYCLONEDX_EXPORT_VEX"), vex)
 }
 
 addtask do_cyclonedx_package_collect before do_build after do_fetch
@@ -55,22 +112,24 @@ do_cyclonedx_package_collect[nostamp] = "1"
 do_cyclonedx_package_collect[lockfiles] += "${CYCLONEDX_EXPORT_LOCK}"
 do_rootfs[recrdeptask] += "do_cyclonedx_package_collect"
 
-def read_sbom(d):
+def read_json(path):
     import json
     from pathlib import Path
-    return json.loads(Path(d.getVar("CYCLONEDX_EXPORT_SBOM")).read_text())
+    return json.loads(Path(path).read_text())
 
-def write_sbom(d, sbom):
+def write_json(path, content):
     import json
     from pathlib import Path
-    Path(d.getVar("CYCLONEDX_EXPORT_SBOM")).write_text(
-        json.dumps(sbom, indent=2)
+    Path(path).write_text(
+        json.dumps(content, indent=2)
     )
 
 def generate_packages_list(products_names, version):
     """
     Get a list of products and generate CPE and PURL identifiers for each of them.
     """
+    import uuid
+
     packages = []
 
     # keep only the short version which can be matched against vulnerabilities databases
@@ -78,7 +137,6 @@ def generate_packages_list(products_names, version):
 
     # some packages have alternative names, so we split CVE_PRODUCT
     for product in products_names.split():
-
         # CVE_PRODUCT in recipes may include vendor information for CPE identifiers. If not,
         # use wildcard for vendor.
         if ":" in product:
@@ -91,7 +149,8 @@ def generate_packages_list(products_names, version):
             "version": version,
             "type": "library",
             "cpe": 'cpe:2.3:*:{}:{}:{}:*:*:*:*:*:*:*'.format(vendor or "*", product, version),
-            "purl": 'pkg:{}/{}@{}'.format(vendor or "generic", product, version)
+            "purl": 'pkg:{}/{}@{}'.format(vendor or "generic", product, version),
+            "bom-ref": str(uuid.uuid4())
         }
         if vendor != "":
             pkg["group"] = vendor


### PR DESCRIPTION
The OE build system contains information on fixed (e.g. backported)
or ignored CVEs (e.g. limited to Windows platforms).

To take these into account we create and populate a CycloneDX VEX file
alongside with the sbom.