### PR TITLE
purl: fix format

### DIFF
--- a/classes/cyclonedx-export.bbclass
+++ b/classes/cyclonedx-export.bbclass
@@ -176,7 +176,7 @@ def generate_packages_list(products_names, version):
             "version": version,
             "type": "library",
             "cpe": 'cpe:2.3:*:{}:{}:{}:*:*:*:*:*:*:*'.format(vendor or "*", product, version),
-            "purl": 'pkg:{}/{}@{}'.format(vendor or "generic", product, version),
+            "purl": 'pkg:generic/{}{}@{}'.format(f"{vendor}/" if vendor else '', product, version),
             "bom-ref": str(uuid.uuid4())
         }
         if vendor != "":


### PR DESCRIPTION
PURL format is not purl:vendor/... or purl:generic/... It's in fact purl:generic/vendor/... or purl:generic/... This commit fix this small error