### PR TITLE
Repl deprecated CVE_CHECK_IGNORE with CVE_STATUS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,6 +6,8 @@ Copyright (C) 2024 iris-GmbH infrared & intelligent sensors
 Based on previous work from `github.com/bgnetworks/meta-dependencytrack`:  
 Copyright 2022 BG Networks, Inc.
 
+Includes code snippet which is Copyright (C) 2023 Andrej Valek <andrej.valek@siemens.com>
+
 ---
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -2,3 +2,9 @@
 
 # We have a conf and classes directory, append to BBPATH
 BBPATH .= ":${LAYERDIR}"
+
+BBFILE_COLLECTIONS += "cyclonedx"
+BBFILE_PATTERN_cyclonedx = "^${LAYERDIR}/"
+
+LAYERDEPENDS_cyclonedx = "core"
+LAYERSERIES_COMPAT_cyclonedx = "styhead"


### PR DESCRIPTION
Yocto releases after Kirkstone have deprecated CVE_CHECK_IGNORE in favour of CVE_STATUS. Updating VEX handling of patched and ignored CVEs accordingly.

CVE_STATUS will also provide additional details about a specific CVE's
status, using the detail and description fields.

Attached is a vex for core-image-minimal, which has been created with this changeset:

[vex.json](https://github.com/user-attachments/files/16560311/vex.json)

In order to continue support for kirkstone (an active LTS release) we would have to do one of the following before merging:

a) create release specific branches, like other OE repositories do (my preference)
b) copy the logic decode_cve_status from oe.cve_check into the bbclass

@loulou123546 WDYT?