### PR TITLE
layer.conf: Suppress warning due to missing bb files

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -6,5 +6,8 @@ BBPATH .= ":${LAYERDIR}"
 BBFILE_COLLECTIONS += "cyclonedx"
 BBFILE_PATTERN_cyclonedx = "^${LAYERDIR}/"
 
+# This layer does not contain any .bb file, only a .bbclass.
+BBFILE_PATTERN_IGNORE_EMPTY_cyclonedx = "1"
+
 LAYERDEPENDS_cyclonedx = "core"
 LAYERSERIES_COMPAT_cyclonedx = "styhead"


### PR DESCRIPTION
The meta-cyclonedx layer only provides a single .bbclass and no .bb files. As a result, BitBake emits the following warning:

WARNING: No bb files in default matched BBFILE_PATTERN_cyclonedx

This PR suppresses the warning by setting
BBFILE_PATTERN_IGNORE_EMPTY, which avoids unnecessary noise during builds.